### PR TITLE
Fixing the requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ tensorflow-hub==0.12.0
 tensorflow_io==0.18.0
 tensorflow_datasets==4.3.0
 tensorflow==2.5.0
+tensorflow-probability==0.13.0
 tensorflow-addons==0.13.0
 absl-py==0.12.0
 flax @ git+https://github.com/google/flax.git@8b2e56e93602ff9fcd62647f28b8145e0e0c10a8

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ tensorflow_io==0.18.0
 tensorflow_datasets==4.3.0
 tensorflow==2.5.0
 tensorflow-addons==0.13.0
-tensorboard==2.4.1
 absl-py==0.12.0
 flax @ git+https://github.com/google/flax.git@8b2e56e93602ff9fcd62647f28b8145e0e0c10a8
 jax==0.2.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ flax @ git+https://github.com/google/flax.git@8b2e56e93602ff9fcd62647f28b8145e0e
 jax==0.2.18
 jaxlib==0.1.69
 scikit-image
+odl

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ absl-py==0.12.0
 flax @ git+https://github.com/google/flax.git@8b2e56e93602ff9fcd62647f28b8145e0e0c10a8
 jax==0.2.18
 jaxlib==0.1.69
+scikit-image

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,6 @@ jax==0.2.18
 jaxlib==0.1.69
 scikit-image
 odl
+piq
+torch
+torchvision


### PR DESCRIPTION
When installing the requirements file (`pip install -r requirements.txt`), I found the following error:

```
ERROR: Cannot install -r requirements.txt (line 6) and tensorboard==2.4.1 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested tensorboard==2.4.1
    tensorflow 2.5.0 depends on tensorboard~=2.5

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```

I am using Python 3.9.

I just suggest to get rid of the strict version req on tensorboard, as it is installed by TensorFlow anyway.


I also added `scikit-image` to the requirements file as it is needed when evaluating for the image quality metrics. Similarly I added `piq`, `torch` and `torchvision`
I also added `odl` as needed as well for CT.
For all of these packages I do not know which version should be used.

I pinned the `tensorflow-probability` version to make sure it matches that of `tensorflow` and that it can be used with `tensorflow-gan`.